### PR TITLE
CMakeLists.txt: Use PATH type for RETDEC_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ set(CUTTER_SOURCE_DIR CUTTER_SOURCE_DIR-NOTFOUND CACHE STRING "Root directory of
 
 option(BUILD_CUTTER_PLUGIN "Build r2ghidra plugin for Cutter" OFF)
 option(BUILD_BUNDLED_RETDEC "Build retdec with the r2retdec plugin" ON)
-set(RETDEC_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE STRING "RetDec installation prefix (if bundled RetDec build is OFF r2plugin will search this directory implicitly in order to find a RetDec installation)")
+set(RETDEC_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE PATH "RetDec installation prefix (if bundled RetDec build is OFF r2plugin will search this directory implicitly in order to find a RetDec installation)")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
If you pass `-DRETDEC_INSTALL_PREFIX=~/.local` as is with `STRING`, you will get the exact string `~/.local` compiled into the binary, which won't work because of the '~'.

By the way, great job on the plugin. I love it!