### PR TITLE
Emit RAnnotatedCode from decompileAt()

### DIFF
--- a/cutter-plugin/CMakeLists.txt
+++ b/cutter-plugin/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(Qt5 REQUIRED COMPONENTS Widgets)
 add_library(r2retdec_cutter SHARED ${SOURCE})
 target_link_libraries(r2retdec_cutter Qt5::Widgets)
 target_link_libraries(r2retdec_cutter Radare2::libr)
+target_link_libraries(r2retdec_cutter core_retdec)
 
 #find_package(Cutter REQUIRED)
 target_link_libraries(r2retdec_cutter Cutter::Cutter)

--- a/cutter-plugin/R2RetDec.cpp
+++ b/cutter-plugin/R2RetDec.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "R2RetDec.h"
-#include "../include/r2plugin/r2retdec.h"
+#include "r2plugin/r2retdec.h"
 #include <Cutter.h>
 
 #include <QJsonDocument>

--- a/cutter-plugin/R2RetDec.cpp
+++ b/cutter-plugin/R2RetDec.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "R2RetDec.h"
-
+#include "../include/r2plugin/r2retdec.h"
 #include <Cutter.h>
 
 #include <QJsonDocument>
@@ -22,51 +22,9 @@ R2RetDec::R2RetDec(QObject *parent)
 
 void R2RetDec::decompileAt(RVA addr)
 {
-	if(task)
-		return;
-
-	AnnotatedCode code = {};
-
-	task = new R2Task ("pdzj @ " + QString::number(addr));
-
-	connect(task, &R2Task::finished, this, [this]() {
-		AnnotatedCode code = {};
-		QString s;
-
-		QJsonObject json = task->getResultJson().object();
-		delete task;
-		task = nullptr;
-		if(json.isEmpty())
-		{
-			code.code = tr("Failed to parse JSON from r2retdec");
-			emit finished(code);
-			return;
-		}
-
-		auto root = json;
-		code.code = root["code"].toString();
-
-		for(QJsonValueRef annotationValue : root["annotations"].toArray())
-		{
-			QJsonObject annotationObject = annotationValue.toObject();
-			CodeAnnotation annotation = {};
-			annotation.start = (size_t)annotationObject["start"].toVariant().toULongLong();
-			annotation.end = (size_t)annotationObject["end"].toVariant().toULongLong();
-			if(annotationObject["type"].toString() == "offset")
-			{
-				annotation.type = CodeAnnotation::Type::Offset;
-				annotation.offset.offset = annotationObject["offset"].toVariant().toULongLong();
-			}
-			else
-				continue;
-			code.annotations.push_back(annotation);
-		}
-
-		for(QJsonValueRef error : json["errors"].toArray())
-			code.code += "// " + error.toString() + "\n";
-
-		emit finished(code);
-	});
-	task->startTask();
-
+	RAnnotatedCode *code = r2retdec_decompile_annotated_code(Core()->core(), addr);
+	if(code == nullptr){
+		code = r_annotated_code_new(strdup("RetDec Decompiler Error: No function at this offset"));
+	}
+	emit finished(code);
 }

--- a/deps/cutter/CMakeLists.txt
+++ b/deps/cutter/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 
 FetchContent_Declare(cutter
 	GIT_REPOSITORY https://github.com/radareorg/cutter
-	GIT_TAG v1.10.3
+	GIT_TAG master
 )
 
 FetchContent_GetProperties(cutter)

--- a/include/r2plugin/r2info.h
+++ b/include/r2plugin/r2info.h
@@ -29,7 +29,7 @@ public:
 public:
 	std::string fetchFilePath() const;
 
-	common::Function fetchCurrentFunction() const;
+	common::Function fetchCurrentFunction(ut64 addr) const;	
 
 	void fetchFunctionsAndGlobals(config::Config &rdconfig) const;
 

--- a/include/r2plugin/r2retdec.h
+++ b/include/r2plugin/r2retdec.h
@@ -1,0 +1,9 @@
+#ifndef R2RETDEC_H
+#define R2RETDEC_H
+
+#include <r_util/r_annotated_code.h>
+#include <r_core.h>
+
+RAnnotatedCode* r2retdec_decompile_annotated_code(RCore *core, ut64 addr);
+
+#endif //R2RETDEC_H

--- a/src/r2info.cpp
+++ b/src/r2info.cpp
@@ -51,14 +51,16 @@ std::string R2InfoProvider::fetchFilePath() const
 }
 
 /**
- * @brief Fetches the currently seeked function in Radare2 console.
+ * @brief Fetches the function at the address passed as parameter.
+ * 
+ * @param addr Analyzes the function at the given address.
  */
-Function R2InfoProvider::fetchCurrentFunction() const
+Function R2InfoProvider::fetchCurrentFunction(ut64 addr) const
 {
-	RAnalFunction *cf = r_anal_get_fcn_in(_r2core.anal, _r2core.offset, R_ANAL_FCN_TYPE_NULL);
+	RAnalFunction *cf = r_anal_get_fcn_in(_r2core.anal, addr, R_ANAL_FCN_TYPE_NULL);
 	if (cf == nullptr) {
 		std::ostringstream errMsg;
-		errMsg << "no function at offset 0x" << std::hex << _r2core.offset;
+		errMsg << "no function at offset 0x" << std::hex << addr;
 		throw DecompilationError(errMsg.str());
 	}
 


### PR DESCRIPTION
This PR is from the Cutter team.  We have a series of work going on for improving the decompiler widget as mentioned in PR #16 . Now we have changed the decompiler widget to base it directly on `RAnnotatedCode` removing the custom `AnnotatedCode` struct that was present in Cutter. The changes have been merged to the master branch in Cutter. This PR contains necessary changes required to make retdec-r2plugin work with the updated Cutter. It seems to be working as well as it was before. But I am not entirely sure if I missed anything important. 